### PR TITLE
Support subject and body of commit messages as dedicated variables

### DIFF
--- a/src/main/java/com/github/novotnyr/idea/git/GitService.java
+++ b/src/main/java/com/github/novotnyr/idea/git/GitService.java
@@ -89,4 +89,26 @@ public class GitService {
             return Optional.empty();
         }
     }
+
+    public Optional<String> getLastCommitMessageSubject(Project project) {
+        Optional<String> lastCommitMessage = getLastCommitMessage(project);
+        if (lastCommitMessage.isPresent()) {
+            String commitMessage = lastCommitMessage.get();
+            if (commitMessage.contains(System.lineSeparator())) {
+                return Optional.of(commitMessage.substring(0, commitMessage.indexOf(System.lineSeparator())).trim());
+            }
+        }
+        return lastCommitMessage;
+    }
+
+    public Optional<String> getLastCommitMessageBody(Project project) {
+        Optional<String> lastCommitMessage = getLastCommitMessage(project);
+        if (lastCommitMessage.isPresent()) {
+            String commitMessage = lastCommitMessage.get();
+            if (commitMessage.contains(System.lineSeparator())) {
+                return Optional.of(commitMessage.substring(commitMessage.indexOf(System.lineSeparator())).trim());
+            }
+        }
+        return lastCommitMessage;
+    }
 }

--- a/src/main/java/com/github/novotnyr/idea/gitlab/quickmr/PlaceholderResolver.java
+++ b/src/main/java/com/github/novotnyr/idea/gitlab/quickmr/PlaceholderResolver.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 public class PlaceholderResolver {
     public static final String LAST_COMMIT_MESSAGE_PLACEHOLDER = "lastCommitMessage";
+    public static final String LAST_COMMIT_MESSAGE_SUBJECT_PLACEHOLDER = "lastCommitMessageSubject";
+    public static final String LAST_COMMIT_MESSAGE_BODY_PLACEHOLDER = "lastCommitMessageBody";
     public static final String SOURCE_BRANCH_PLACEHOLDER = "sourceBranch";
     public static final String TARGET_BRANCH_PLACEHOLDER = "targetBranch";
 
@@ -33,6 +35,18 @@ public class PlaceholderResolver {
             if(maybeLastCommitMessage.isPresent()) {
                 String lastCommitMessage = maybeLastCommitMessage.get();
                 buffer = buffer.replaceAll("\\{\\{lastCommitMessage}}", lastCommitMessage);
+            }
+        }
+        if (LAST_COMMIT_MESSAGE_SUBJECT_PLACEHOLDER.equalsIgnoreCase(placeholder.trim())) {
+            Optional<String> subject = gitService.getLastCommitMessageSubject(this.project);
+            if(subject.isPresent()) {
+                buffer = buffer.replaceAll("\\{\\{lastCommitMessageSubject}}", subject.get());
+            }
+        }
+        if (LAST_COMMIT_MESSAGE_BODY_PLACEHOLDER.equalsIgnoreCase(placeholder.trim())) {
+            Optional<String> body = gitService.getLastCommitMessageBody(this.project);
+            if(body.isPresent()) {
+                buffer = buffer.replaceAll("\\{\\{lastCommitMessageBody}}", body.get());
             }
         }
         if (SOURCE_BRANCH_PLACEHOLDER.equalsIgnoreCase(placeholder.trim())) {

--- a/src/main/java/com/github/novotnyr/idea/gitlab/quickmr/settings/SettingsUi.form
+++ b/src/main/java/com/github/novotnyr/idea/gitlab/quickmr/settings/SettingsUi.form
@@ -214,7 +214,7 @@
         </constraints>
         <properties>
           <font size="11"/>
-          <text value="Placeholders: {{sourceBranch}}, {{targetBranch}}, {{lastCommitMessage}}"/>
+          <text value="Placeholders: {{sourceBranch}}, {{targetBranch}}, {{lastCommitMessage}}, {{lastCommitMessageSubject}}, {{lastCommitMessageBody}}"/>
         </properties>
       </component>
       <component id="e1dd0" class="javax.swing.JLabel">


### PR DESCRIPTION
Typically, a git commit message has a single subject line and a body. Support both as dedicated variables in the PlaceholderResolver to be able to use the subject as the MR title and the body as the description of the MR.